### PR TITLE
Drop support for Go master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: go
 go:
   - 1.7.x
   - 1.8.x
-  - master
 
 before_install:
   - go get github.com/mattn/goveralls


### PR DESCRIPTION
Testing against Go master takes a long time and provides no real
benefit, aside from flagging issues before a stable release is made.